### PR TITLE
Add shutter sound

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
  - docker
 
 env:
- - DEPENDENCY_PACKAGES="appstream cmake intltool libclutter-gst-3.0-dev libclutter-gtk-1.0-dev libgranite-dev libgtk-3-dev valac desktop-file-utils"
+ - DEPENDENCY_PACKAGES="appstream cmake intltool libclutter-gst-3.0-dev libclutter-gtk-1.0-dev libgranite-dev libgtk-3-dev valac desktop-file-utils libcanberra-dev"
 
 install:
  - docker pull elementary/docker:loki

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ add_definitions (-w)
 
 # Dependencies
 find_package (PkgConfig)
-set (SNAP_DEPS gio-2.0 gee-0.8 gtk+-3.0 granite clutter-gst-3.0 clutter-gtk-1.0 gsound)
+set (SNAP_DEPS gio-2.0 gee-0.8 gtk+-3.0 granite clutter-gst-3.0 clutter-gtk-1.0 libcanberra)
 pkg_check_modules (DEPS REQUIRED ${SNAP_DEPS})
 
 # Linking paramaters

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ add_definitions (-w)
 
 # Dependencies
 find_package (PkgConfig)
-set (SNAP_DEPS gio-2.0 gee-0.8 gtk+-3.0 granite clutter-gst-3.0 clutter-gtk-1.0)
+set (SNAP_DEPS gio-2.0 gee-0.8 gtk+-3.0 granite clutter-gst-3.0 clutter-gtk-1.0 gsound)
 pkg_check_modules (DEPS REQUIRED ${SNAP_DEPS})
 
 # Linking paramaters

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You'll need the following dependencies:
  - libgranite-dev
  - libclutter-gst-3.0-dev
  - libclutter-gtk-1.0-dev
+ - libgsound-dev
 
 It's recommended to create a clean build environment
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You'll need the following dependencies:
  - libgranite-dev
  - libclutter-gst-3.0-dev
  - libclutter-gtk-1.0-dev
- - libgsound-dev
+ - libcanberra-dev
 
 It's recommended to create a clean build environment
 

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -56,41 +56,4 @@ namespace Camera.Utils {
 
         return GLib.Path.build_path (Path.DIR_SEPARATOR_S, media_directory, "Webcam");
     }
-
-    public class Shutter : Object {
-        private GLib.Settings settings;
-        private GSound.Context? gsound;
-        private GLib.Cancellable cancellable;
-        private string soundtheme;
-
-        public Shutter () {
-            settings = new GLib.Settings("org.gnome.desktop.sound");
-
-            try {
-                gsound = new GSound.Context();
-            } catch (GLib.Error e) {
-                warning ("Sound could not be initialized, error: %s", e.message);
-            }
-
-            soundtheme = settings.get_string ("theme-name");
-            cancellable = new GLib.Cancellable();
-        }
-
-        public async void play () {
-            if (gsound == null) {
-                return;
-            }
-
-            try {
-                yield gsound.play_full (cancellable,
-                                        GSound.Attribute.EVENT_ID, "camera-shutter",
-                                        GSound.Attribute.CANBERRA_XDG_THEME_NAME, soundtheme,
-                                        GSound.Attribute.MEDIA_ROLE, "event");
-            } catch (GLib.IOError.CANCELLED e) {
-                // ignore
-            } catch (GLib.Error e) {
-                warning ("Error playing sound: %s", e.message);
-            }
-        }
-    }
 }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -56,4 +56,41 @@ namespace Camera.Utils {
 
         return GLib.Path.build_path (Path.DIR_SEPARATOR_S, media_directory, "Webcam");
     }
+
+    public class Shutter : Object {
+        private GLib.Settings settings;
+        private GSound.Context? gsound;
+        private GLib.Cancellable cancellable;
+        private string soundtheme;
+
+        public Shutter () {
+            settings = new GLib.Settings("org.gnome.desktop.sound");
+
+            try {
+                gsound = new GSound.Context();
+            } catch (GLib.Error e) {
+                warning ("Sound could not be initialized, error: %s", e.message);
+            }
+
+            soundtheme = settings.get_string ("theme-name");
+            cancellable = new GLib.Cancellable();
+        }
+
+        public async void play () {
+            if (gsound == null) {
+                return;
+            }
+
+            try {
+                yield gsound.play_full (cancellable,
+                                        GSound.Attribute.EVENT_ID, "camera-shutter",
+                                        GSound.Attribute.CANBERRA_XDG_THEME_NAME, soundtheme,
+                                        GSound.Attribute.MEDIA_ROLE, "event");
+            } catch (GLib.IOError.CANCELLED e) {
+                // ignore
+            } catch (GLib.Error e) {
+                warning ("Error playing sound: %s", e.message);
+            }
+        }
+    }
 }

--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -21,8 +21,11 @@
 
 public class Camera.Widgets.CameraView : ClutterGst.Camera {
     public signal void initialized ();
+    private Utils.Shutter shutter;
 
     public CameraView () {
+        shutter = new Utils.Shutter();
+
         new Thread<int> (null, () => {
             debug ("Initializing camera view...");
 
@@ -39,6 +42,7 @@ public class Camera.Widgets.CameraView : ClutterGst.Camera {
             return false;
         }
 
+        shutter.play.begin ();
         base.take_photo (Utils.get_new_media_filename (Utils.ActionType.PHOTO));
 
         return true;

--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -21,11 +21,8 @@
 
 public class Camera.Widgets.CameraView : ClutterGst.Camera {
     public signal void initialized ();
-    private Utils.Shutter shutter;
 
     public CameraView () {
-        shutter = new Utils.Shutter();
-
         new Thread<int> (null, () => {
             debug ("Initializing camera view...");
 
@@ -42,8 +39,8 @@ public class Camera.Widgets.CameraView : ClutterGst.Camera {
             return false;
         }
 
-        shutter.play.begin ();
         base.take_photo (Utils.get_new_media_filename (Utils.ActionType.PHOTO));
+        play_shutter_sound ();
 
         return true;
     }
@@ -88,5 +85,20 @@ public class Camera.Widgets.CameraView : ClutterGst.Camera {
         } else {
             warning ("Initializing camera view failed.");
         }
+    }
+
+    private void play_shutter_sound () {
+        Canberra.Context context;
+        Canberra.Proplist props;
+
+        Canberra.Context.create (out context);
+        Canberra.Proplist.create (out props);
+
+        props.sets (Canberra.PROP_EVENT_ID, "camera-shutter");
+        props.sets (Canberra.PROP_EVENT_DESCRIPTION, _("Photo taken"));
+        props.sets (Canberra.PROP_CANBERRA_CACHE_CONTROL, "permanent");
+        props.sets (Canberra.PROP_MEDIA_ROLE, "event");
+
+        context.play_full (0, props, null);
     }
 }


### PR DESCRIPTION
Adds a shutter sound when taking a photo. From issue #7 

- Uses GSound to play the stock "camera-shutter" sound when a photo is being taken
- Depends on libgsound-dev (added in readme)
- Tested on Fedora 25 (Gnome), haven't tested on elementary OS
- I can't work out how to do the flash yet