### PR TITLE
don't install extra.mo files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The camera app designed for elementary OS
 
 You'll need the following dependencies:
 
- - meson
+ - meson >= 0.43
  - valac-0.30
  - libgtk-3.0-dev
  - libgranite-dev

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,7 @@
-project('pantheon-camera', 'vala', 'c')
+project(
+    'pantheon-camera', 'vala', 'c',
+    meson_version : '>= 0.43'
+)
 
 app_name = 'org.pantheon.camera'
 

--- a/po/extra/meson.build
+++ b/po/extra/meson.build
@@ -1,4 +1,5 @@
 i18n.gettext(
     'extra',
-    args : '--directory=' + meson.source_root()
+    args : '--directory=' + meson.source_root(),
+    install : false
 )


### PR DESCRIPTION
This is the analog to the already merged fixes for calculator and screenshot-tool. It's not a problem yet, since there are no translations for the .desktop and .appdata.xml files (yet). However, once they were to be added, extra.mo files would have been installed.

This uses the new "install" argument to the i18n.gettext() call in meson, which is only present in version 0.43.0 and later. This requirement has been added in meson.build and noted in the build requirements listed in README.md.