### PR TITLE
Cap Resolution

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -114,6 +114,8 @@ public class Camera.MainWindow : Gtk.Window {
 
     private void initialize_camera_view () {
         camera_view = new Widgets.CameraView ();
+        camera_view.get_camera_device ().set_capture_resolution (640, 480);
+
         camera_view.initialized.connect (() => {
             header_bar.camera_controls_sensitive = true;
             stack.set_visible_child_name ("camera");


### PR DESCRIPTION
This sets the resolution to 640×480, which appears to be the default for Cheese as well (which is why Cheese often works with certain higher-res cameras when Camera does not). Ideally we could be smarter about this and _possibly_ even expose supported resolutions, but this at least gets it working as well as Cheese ootb.

I've kept this as a draft because I doubt we'd be okay just dropping to this resolution full-time, so it'll need some input and thought.