### PR TITLE
Handle null camera name

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -138,7 +138,7 @@ public class Camera.MainWindow : Gtk.ApplicationWindow {
         camera_content.set_player (camera_view);
 
          if  (camera_view.get_camera_device ().get_name () == null) {
-            loading_view.set_status (_("Connecting to \"%s\"…").printf ("camera"));
+            loading_view.set_status (_("Connecting to %s…").printf ("camera"));
         } else {
             loading_view.set_status (_("Connecting to \"%s\"…").printf (camera_view.get_camera_device ().get_name ()));
         }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -137,7 +137,12 @@ public class Camera.MainWindow : Gtk.ApplicationWindow {
 
         camera_content.set_player (camera_view);
 
-        loading_view.set_status (_("Connecting to %s…").printf (camera_name));
+         if  (camera_view.get_camera_device ().get_name () == null) {
+            loading_view.set_status (_("Connecting to \"%s\"…").printf ("camera"));
+        } else {
+            loading_view.set_status (_("Connecting to \"%s\"…").printf (camera_view.get_camera_device ().get_name ()));
+        }
+    
     }
 
     private void on_fullscreen () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -110,7 +110,7 @@ public class Camera.MainWindow : Gtk.ApplicationWindow {
         Idle.add (() => {
             GenericArray<ClutterGst.CameraDevice> camera_devices = camera_manager.get_camera_devices ();
 
-            if (camera_devices.length > 0 && camera_devices[0].get_name () != null) {
+            if (camera_devices.length > 0) {
                 initialize_camera_view ();
             } else {
                 stack.set_visible_child_name ("no-device");

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -32,6 +32,7 @@ public class Camera.MainWindow : Gtk.ApplicationWindow {
     };
 
     private uint configure_id;
+    private string camera_name = _("camera");
 
     private Gtk.Stack stack;
     private Granite.Widgets.AlertView no_device_view;
@@ -110,6 +111,10 @@ public class Camera.MainWindow : Gtk.ApplicationWindow {
         Idle.add (() => {
             GenericArray<ClutterGst.CameraDevice> camera_devices = camera_manager.get_camera_devices ();
 
+            if (camera_devices[0].get_name () != null) {
+                camera_name = camera_devices[0].get_name ();
+            }
+
             if (camera_devices.length > 0) {
                 initialize_camera_view ();
             } else {
@@ -132,7 +137,7 @@ public class Camera.MainWindow : Gtk.ApplicationWindow {
 
         camera_content.set_player (camera_view);
 
-        loading_view.set_status (_("Connecting to \"%s\"…").printf (camera_view.get_camera_device ().get_name ()));
+        loading_view.set_status (_("Connecting to %s…").printf (camera_name));
     }
 
     private void on_fullscreen () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -110,7 +110,7 @@ public class Camera.MainWindow : Gtk.ApplicationWindow {
         Idle.add (() => {
             GenericArray<ClutterGst.CameraDevice> camera_devices = camera_manager.get_camera_devices ();
 
-            unowned string camera_name = camera_devices[0].get_name () ?? "camera";
+            unowned string camera_name = camera_devices[0].get_name () ?? _("camera");
 
             if (camera_devices.length > 0) {
                 initialize_camera_view (camera_name);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -32,7 +32,6 @@ public class Camera.MainWindow : Gtk.ApplicationWindow {
     };
 
     private uint configure_id;
-    private string camera_name = _("camera");
 
     private Gtk.Stack stack;
     private Granite.Widgets.AlertView no_device_view;
@@ -111,12 +110,10 @@ public class Camera.MainWindow : Gtk.ApplicationWindow {
         Idle.add (() => {
             GenericArray<ClutterGst.CameraDevice> camera_devices = camera_manager.get_camera_devices ();
 
-            if (camera_devices[0].get_name () != null) {
-                camera_name = camera_devices[0].get_name ();
-            }
+            unowned string camera_name = camera_devices[0].get_name () ?? "camera";
 
             if (camera_devices.length > 0) {
-                initialize_camera_view ();
+                initialize_camera_view (camera_name);
             } else {
                 stack.set_visible_child_name ("no-device");
 
@@ -127,7 +124,7 @@ public class Camera.MainWindow : Gtk.ApplicationWindow {
         });
     }
 
-    private void initialize_camera_view () {
+    private void initialize_camera_view (string camera_name) {
         camera_view = new Widgets.CameraView ();
         camera_view.get_camera_device ().set_capture_resolution (640, 480);
 
@@ -136,13 +133,7 @@ public class Camera.MainWindow : Gtk.ApplicationWindow {
         });
 
         camera_content.set_player (camera_view);
-
-         if  (camera_view.get_camera_device ().get_name () == null) {
-            loading_view.set_status (_("Connecting to %s…").printf ("camera"));
-        } else {
-            loading_view.set_status (_("Connecting to \"%s\"…").printf (camera_view.get_camera_device ().get_name ()));
-        }
-    
+        loading_view.set_status (_("Connecting to %s…").printf (camera_name));
     }
 
     private void on_fullscreen () {


### PR DESCRIPTION
Fixes #103

### Changes Summary

- removing ` && camera_devices[0].get_name () != null`

My webcam name is "null", that's why the app wasn't working. After removing this part of code everything works fine.
