### PR TITLE
TimerButton: simpler image and label

### DIFF
--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -47,6 +47,7 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
 
     construct {
         timer_button = new Widgets.TimerButton ();
+        timer_button.image = new Gtk.Image.from_icon_name ("timer-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
 
         take_image = new Gtk.Image ();
         take_image.icon_name = PHOTO_ICON_SYMBOLIC;

--- a/src/Widgets/TimerButton.vala
+++ b/src/Widgets/TimerButton.vala
@@ -52,21 +52,16 @@ public class Camera.Widgets.TimerButton : Gtk.Button {
     construct {
         delay = (Delay) Camera.Application.settings.get_enum ("delay");
 
-        var timer_image = new Gtk.Image.from_icon_name ("timer-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-        var timer_label = new Gtk.Label (delay.to_string ());
+        label = delay.to_string ();
 
         this.clicked.connect (() => {
             delay = delay.next ();
             Camera.Application.settings.set_enum ("delay", delay);
-            timer_label.label = delay.to_string ();
+            label = delay.to_string ();
         });
 
-        var main_grid = new Gtk.Grid ();
-        main_grid.add (timer_image);
-        main_grid.add (timer_label);
-
+        always_show_image = true;
         tooltip_text = _("Delay before photo is taken");
         get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        add (main_grid);
     }
 }


### PR DESCRIPTION
Use the `always_show_image` property instead of manually packing a grid

For some reason Gtk complains if we add the image inside the button subclass, so we do it in headerbar