### PR TITLE
Add brightness and contrast adjustments

### DIFF
--- a/data/icons/symbolic/object-inverse-symbolic.svg
+++ b/data/icons/symbolic/object-inverse-symbolic.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" height="16" width="16" id="svg2" version="1.1" inkscape:version="0.91 r13725" sodipodi:docname="object-inverse-symbolic.svg">
+  <metadata id="metadata14">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id="defs12"/>
+  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1920" inkscape:window-height="1017" id="namedview10" showgrid="false" inkscape:zoom="1" inkscape:cx="-58.060757" inkscape:cy="75.229425" inkscape:window-x="0" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:current-layer="svg2"/>
+  <path inkscape:connector-curvature="0" id="path8" style="color:#bebebe;overflow:visible;fill:#666666;marker:none" overflow="visible" d="M 8,0 C 3.581719,0 3.4729399e-6,3.5817221 3.4729399e-6,8 3.4729399e-6,12.418278 3.581719,16 8,16 12.418281,16 15.999997,12.418278 15.999997,8 15.999997,3.5817221 12.418281,0 8,0 Z m 0,2 c 3.313711,0 5.999997,2.6862916 5.999997,6 0,3.313708 -2.686286,6 -5.999997,6 C 8,8.4168943 8,5.4999507 8,2 Z" sodipodi:nodetypes="ssssscscc"/>
+</svg>

--- a/data/io.elementary.camera.gresource.xml
+++ b/data/io.elementary.camera.gresource.xml
@@ -3,4 +3,7 @@
   <gresource prefix="io/elementary/camera">
     <file alias="timer-symbolic.svg">icons/symbolic/timer-symbolic.svg</file>
   </gresource>
+  <gresource prefix="io/elementary/camera">
+    <file alias="color-contrast-symbolic.svg">icons/symbolic/object-inverse-symbolic.svg</file>
+  </gresource>
 </gresources>

--- a/data/io.elementary.camera.gresource.xml
+++ b/data/io.elementary.camera.gresource.xml
@@ -2,8 +2,6 @@
 <gresources>
   <gresource prefix="io/elementary/camera">
     <file alias="timer-symbolic.svg">icons/symbolic/timer-symbolic.svg</file>
-  </gresource>
-  <gresource prefix="io/elementary/camera">
     <file alias="color-contrast-symbolic.svg">icons/symbolic/object-inverse-symbolic.svg</file>
   </gresource>
 </gresources>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -83,6 +83,8 @@ public class Camera.MainWindow : Hdy.ApplicationWindow {
 
         camera_view.start ();
 
+        show_all ();
+
         header_bar.request_change_balance.connect (camera_view.change_color_balance);
     }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -69,7 +69,6 @@ public class Camera.MainWindow : Hdy.ApplicationWindow {
         header_bar = new Widgets.HeaderBar ();
 
         camera_view = new Widgets.CameraView ();
-        header_bar.request_change_balance.connect (camera_view.change_color_balance);
 
         var grid = new Gtk.Grid ();
         grid.attach (header_bar, 0, 0);
@@ -84,7 +83,7 @@ public class Camera.MainWindow : Hdy.ApplicationWindow {
 
         camera_view.start ();
 
-        show_all ();
+        header_bar.request_change_balance.connect (camera_view.change_color_balance);
     }
 
     private void on_fullscreen () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -69,6 +69,7 @@ public class Camera.MainWindow : Hdy.ApplicationWindow {
         header_bar = new Widgets.HeaderBar ();
 
         camera_view = new Widgets.CameraView ();
+        header_bar.request_change_balance.connect (camera_view.change_color_balance);
 
         var grid = new Gtk.Grid ();
         grid.attach (header_bar, 0, 0);

--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -27,7 +27,6 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
 
     private Gst.Pipeline pipeline;
     private Gst.Element tee;
-    private Gst.Video.Direction hflip;
     private Gst.Video.ColorBalance color_balance;
     private Gst.Bin? record_bin;
 
@@ -120,7 +119,7 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
             pipeline = (Gst.Pipeline) Gst.parse_launch (
                 "v4l2src device=%s name=v4l2src !".printf (camera.get_properties ().get_string ("device.path")) +
                 "video/x-raw, width=640, height=480, framerate=30/1 ! " +
-                "videoflip method=horizontal-flip name=hflip ! " +
+                "videoflip method=horizontal-flip ! " +
                 "videobalance name=balance ! " +
                 "tee name=tee ! " +
                 "queue leaky=downstream max-size-buffers=10 ! " +
@@ -130,7 +129,6 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
             );
 
             tee = pipeline.get_by_name ("tee");
-            hflip = (pipeline.get_by_name ("hflip") as Gst.Video.Direction);
             color_balance = (pipeline.get_by_name ("balance") as Gst.Video.ColorBalance);
 
             var gtksink = pipeline.get_by_name ("gtksink");

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -92,10 +92,11 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
 
 
         var brightness_image = new Gtk.Image.from_icon_name ("display-brightness-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
-        var brightness_label = new Gtk.Label (_("Brightness"));
-        brightness_label.get_style_context ().add_class ("h3");
-        brightness_label.hexpand = true;
-        brightness_label.set_xalign (0);
+        var brightness_label = new Gtk.Label (_("Brightness")) {
+            hexpand = true,
+            xalign = 0
+        };
+        brightness_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
         var contrast_image = new Gtk.Image.from_icon_name ("night-light-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         var constrast_label = new Gtk.Label (_("Contrast"));

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -32,6 +32,9 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
     private Gtk.Image take_image;
     private Granite.ModeSwitch mode_switch;
 
+    public signal void request_horizontal_flip ();
+    public signal void request_change_balance (double brightness, double contrast);
+
     public bool recording { get; set; default = false; }
 
     public int timer_delay {
@@ -88,10 +91,65 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
         mode_switch = new Granite.ModeSwitch.from_icon_name (PHOTO_ICON_SYMBOLIC, VIDEO_ICON_SYMBOLIC);
         mode_switch.valign = Gtk.Align.CENTER;
 
+
+        var brightness_image = new Gtk.Image.from_icon_name ("display-brightness-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        var brightness_label = new Gtk.Label (_("Brightness"));
+        brightness_label.get_style_context ().add_class ("h3");
+        brightness_label.hexpand = true;
+        brightness_label.set_xalign (0);
+
+        var contrast_image = new Gtk.Image.from_icon_name ("night-light-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        var constrast_label = new Gtk.Label (_("Contrast"));
+        constrast_label.get_style_context ().add_class ("h3");
+        constrast_label.hexpand = true;
+        constrast_label.set_xalign (0);
+
+        var brightness_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 1, 0.1);
+        brightness_scale.draw_value = false;
+        brightness_scale.hexpand = true;
+        brightness_scale.set_value (0);
+        brightness_scale.add_mark (0, Gtk.PositionType.BOTTOM, "");
+        brightness_scale.add_mark (1, Gtk.PositionType.BOTTOM, "");
+        
+        var contrast_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 1, 0.1);
+        contrast_scale.draw_value = false;
+        contrast_scale.hexpand = true;
+        contrast_scale.set_value (1.0);
+        contrast_scale.add_mark (0, Gtk.PositionType.BOTTOM, "");
+        contrast_scale.add_mark (1, Gtk.PositionType.BOTTOM, "");
+        
+        brightness_scale.value_changed.connect (() => {
+            request_change_balance (brightness_scale.get_value (), contrast_scale.get_value ());
+        });
+
+        contrast_scale.value_changed.connect (() => {
+            request_change_balance (brightness_scale.get_value (), contrast_scale.get_value ());
+        });
+
+        var image_settings = new Gtk.Grid ();
+        image_settings.row_spacing = 6;
+        image_settings.margin = 6;
+        image_settings.width_request = 250;
+        image_settings.attach (brightness_image, 0, 0, 1, 1);
+        image_settings.attach (brightness_label, 1, 0, 1, 1);
+        image_settings.attach (brightness_scale, 0, 1, 2, 1);
+        image_settings.attach (contrast_image, 0, 2, 1, 1);
+        image_settings.attach (constrast_label, 1, 2, 1, 1);
+        image_settings.attach (contrast_scale, 0, 3, 2, 1);
+        image_settings.show_all ();
+
+        var popover = new Gtk.Popover (null);
+        popover.add (image_settings);
+
+        var but = new Gtk.MenuButton ();
+        but.image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.MENU);
+        but.popover = popover;
+
         show_close_button = true;
         get_style_context ().add_class (Gtk.STYLE_CLASS_TITLEBAR);
         pack_start (timer_button);
         set_custom_title (take_button);
+        pack_end (but);
         pack_end (mode_switch);
 
         Camera.Application.settings.changed.connect ((key) => {

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -109,14 +109,14 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
         brightness_scale.set_value (0);
         brightness_scale.add_mark (0, Gtk.PositionType.BOTTOM, "");
         brightness_scale.add_mark (1, Gtk.PositionType.BOTTOM, "");
-        
+
         var contrast_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 1, 0.1);
         contrast_scale.draw_value = false;
         contrast_scale.hexpand = true;
         contrast_scale.set_value (1.0);
         contrast_scale.add_mark (0, Gtk.PositionType.BOTTOM, "");
         contrast_scale.add_mark (1, Gtk.PositionType.BOTTOM, "");
-        
+
         brightness_scale.value_changed.connect (() => {
             request_change_balance (brightness_scale.get_value (), contrast_scale.get_value ());
         });

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -104,9 +104,10 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
         constrast_label.hexpand = true;
         constrast_label.set_xalign (0);
 
-        var brightness_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 1, 0.1);
-        brightness_scale.draw_value = false;
-        brightness_scale.hexpand = true;
+        var brightness_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 1, 0.1) {
+            draw_value = false,
+            hexpand = true
+        };
         brightness_scale.set_value (0);
         brightness_scale.add_mark (0, Gtk.PositionType.BOTTOM, "");
         brightness_scale.add_mark (1, Gtk.PositionType.BOTTOM, "");

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -32,7 +32,6 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
     private Gtk.Image take_image;
     private Granite.ModeSwitch mode_switch;
 
-    public signal void request_horizontal_flip ();
     public signal void request_change_balance (double brightness, double contrast);
 
     public bool recording { get; set; default = false; }

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -144,10 +144,11 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
         var popover = new Gtk.Popover (null);
         popover.add (image_settings);
 
-        var menu_button = new Gtk.MenuButton ();
-        menu_button.tooltip_text = _("Settings");
-        menu_button.image = new Gtk.Image.from_icon_name ("open-menu-symbolic", Gtk.IconSize.MENU);
-        menu_button.popover = popover;
+        var menu_button = new Gtk.MenuButton () {
+            image = new Gtk.Image.from_icon_name ("open-menu-symbolic", Gtk.IconSize.MENU),
+            popover = popover,
+            tooltip_text = _("Settings")
+        };
 
         show_close_button = true;
         get_style_context ().add_class (Gtk.STYLE_CLASS_TITLEBAR);

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -133,12 +133,12 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
         image_settings.row_spacing = 3;
         image_settings.margin = 6;
         image_settings.width_request = 250;
-        image_settings.attach (brightness_image, 0, 0, 1, 1);
-        image_settings.attach (brightness_label, 1, 0, 1, 1);
-        image_settings.attach (brightness_scale, 0, 1, 2, 1);
-        image_settings.attach (contrast_image, 0, 2, 1, 1);
-        image_settings.attach (constrast_label, 1, 2, 1, 1);
-        image_settings.attach (contrast_scale, 0, 3, 2, 1);
+        image_settings.attach (brightness_image, 0, 0);
+        image_settings.attach (brightness_label, 1, 0);
+        image_settings.attach (brightness_scale, 0, 1, 2);
+        image_settings.attach (contrast_image, 0, 2);
+        image_settings.attach (constrast_label, 1, 2);
+        image_settings.attach (contrast_scale, 0, 3, 2);
         image_settings.show_all ();
 
         var popover = new Gtk.Popover (null);

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -142,7 +142,7 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
         popover.add (image_settings);
 
         var but = new Gtk.MenuButton ();
-        but.image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.MENU);
+        but.image = new Gtk.Image.from_icon_name ("open-menu-symbolic", Gtk.IconSize.MENU);
         but.popover = popover;
 
         show_close_button = true;

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -91,32 +91,33 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
         mode_switch.valign = Gtk.Align.CENTER;
 
 
-        var brightness_image = new Gtk.Image.from_icon_name ("display-brightness-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        var brightness_image = new Gtk.Image.from_icon_name ("display-brightness-symbolic", Gtk.IconSize.MENU);
         var brightness_label = new Gtk.Label (_("Brightness")) {
             hexpand = true,
             xalign = 0
         };
         brightness_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
-        var contrast_image = new Gtk.Image.from_icon_name ("night-light-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
-        var constrast_label = new Gtk.Label (_("Contrast"));
-        constrast_label.get_style_context ().add_class ("h3");
-        constrast_label.hexpand = true;
-        constrast_label.set_xalign (0);
+        var contrast_image = new Gtk.Image.from_icon_name ("color-contrast-symbolic", Gtk.IconSize.MENU);
+        var constrast_label = new Gtk.Label (_("Contrast")) {
+            hexpand = true,
+            xalign = 0
+        };
+        constrast_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
-        var brightness_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 1, 0.1) {
+        var brightness_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, -1, 1, 0.1) {
             draw_value = false,
-            hexpand = true
+            hexpand = true,
+            margin_bottom = 6
         };
         brightness_scale.set_value (0);
         brightness_scale.add_mark (0, Gtk.PositionType.BOTTOM, "");
-        brightness_scale.add_mark (1, Gtk.PositionType.BOTTOM, "");
 
-        var contrast_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 1, 0.1);
-        contrast_scale.draw_value = false;
-        contrast_scale.hexpand = true;
-        contrast_scale.set_value (1.0);
-        contrast_scale.add_mark (0, Gtk.PositionType.BOTTOM, "");
+        var contrast_scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 2, 0.1) {
+            draw_value = false,
+            hexpand = false
+        };
+        contrast_scale.set_value (1);
         contrast_scale.add_mark (1, Gtk.PositionType.BOTTOM, "");
 
         brightness_scale.value_changed.connect (() => {
@@ -128,7 +129,8 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
         });
 
         var image_settings = new Gtk.Grid ();
-        image_settings.row_spacing = 6;
+        image_settings.column_spacing = 3;
+        image_settings.row_spacing = 3;
         image_settings.margin = 6;
         image_settings.width_request = 250;
         image_settings.attach (brightness_image, 0, 0, 1, 1);
@@ -142,15 +144,17 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
         var popover = new Gtk.Popover (null);
         popover.add (image_settings);
 
-        var but = new Gtk.MenuButton ();
-        but.image = new Gtk.Image.from_icon_name ("open-menu-symbolic", Gtk.IconSize.MENU);
-        but.popover = popover;
+        var menu_button = new Gtk.MenuButton ();
+        menu_button.tooltip_text = _("Settings");
+        menu_button.image = new Gtk.Image.from_icon_name ("open-menu-symbolic", Gtk.IconSize.MENU);
+        menu_button.popover = popover;
 
         show_close_button = true;
         get_style_context ().add_class (Gtk.STYLE_CLASS_TITLEBAR);
         pack_start (timer_button);
         set_custom_title (take_button);
-        pack_end (but);
+        pack_end (menu_button);
+        pack_end (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
         pack_end (mode_switch);
 
         Camera.Application.settings.changed.connect ((key) => {


### PR DESCRIPTION
Fix #51  : adds app menu for adjusting brightness and contrast. Most of the design is based on the prototype in #67 . I added the contrast option below, using the `night-light-symbolic` icon. 

![contrast-brightness](https://user-images.githubusercontent.com/221446/93715423-920c1c00-fb3f-11ea-9ef9-e02effa17c9e.gif)

Following the discussions in #67 , IMHO this feature should be in camera as it is useful for recording videos. Although photo editing works well in the *Photos* app, doing this kind of adjustment for videos is much harder and time consuming. Also, all the heavy lifting is done using plugins in GStreamer so there's no need to maintain the same set of filters implemented in two different places. 

Currently these settings are not persistent.