### PR TITLE
Fix restoring window size

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -49,16 +49,25 @@ public class Camera.Application : Gtk.Application {
 
     protected override void activate () {
         if (get_windows () == null) {
-            var rect = Gtk.Allocation ();
-            settings.get ("window-size", "(ii)", out rect.width, out rect.height);
-
             main_window = new MainWindow (this);
-            main_window.set_allocation (rect);
+
+            int width, height;
+            settings.get ("window-size", "(ii)", out width, out height);
+
+            var hints = Gdk.Geometry ();
+            hints.min_aspect = 1.0;
+            hints.max_aspect = 1.8;
+            hints.min_width = 436;
+            hints.min_height = 352;
+
+            main_window.set_geometry_hints (null, hints, Gdk.WindowHints.ASPECT | Gdk.WindowHints.MIN_SIZE);
+            main_window.resize (width, height);
 
             if (settings.get_boolean ("window-maximized")) {
                 main_window.maximize ();
             }
 
+            main_window.window_position = Gtk.WindowPosition.CENTER;
             main_window.show_all ();
         } else {
             main_window.present ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -62,9 +62,6 @@ public class Camera.MainWindow : Hdy.ApplicationWindow {
 
         this.title = _("Camera");
         icon_name = "io.elementary.camera";
-        set_default_size (640, 480);
-        set_size_request (436, 352);
-        this.window_position = Gtk.WindowPosition.CENTER;
 
         header_bar = new Widgets.HeaderBar ();
 
@@ -102,7 +99,6 @@ public class Camera.MainWindow : Hdy.ApplicationWindow {
             }
         });
 
-
         var grid = new Gtk.Grid ();
         grid.attach (header_bar, 0, 0);
         grid.attach (overlay, 0, 1);
@@ -123,7 +119,6 @@ public class Camera.MainWindow : Hdy.ApplicationWindow {
         camera_view.start ();
 
         header_bar.request_change_balance.connect (camera_view.change_color_balance);
-        show_all ();
     }
 
     private void on_fullscreen () {
@@ -174,10 +169,9 @@ public class Camera.MainWindow : Hdy.ApplicationWindow {
                 Application.settings.set_boolean ("window-maximized", true);
             } else {
                 Application.settings.set_boolean ("window-maximized", false);
-
-                Gdk.Rectangle rect;
-                get_allocation (out rect);
-                Application.settings.set ("window-size", "(ii)", rect.width, rect.height);
+                int width, height;
+                get_size (out width, out height);
+                Application.settings.set ("window-size", "(ii)", width, height);
             }
 
             return false;


### PR DESCRIPTION
Fixes #183

Although the window size was being stored in settings, it was not being restored effectively.

* Move all initial Window geometry setting to Application.vala
* Apply geometry hints to window
* Use get_size () and set_size ()
* Do not show window until settings applied

This PR also mitigates #170.  Now the black bars can be removed by manually adjusting the window dimensions and they will not reappear when the app is restarted.