### PR TITLE
Do not rely on display name to distinguish devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 build/
 src/config.vala
+flatpak*
+.flatpak*

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -115,10 +115,8 @@ public class Camera.MainWindow : Hdy.ApplicationWindow {
         timer_running = false;
         camera_view.camera_added.connect (header_bar.add_camera_option);
         camera_view.camera_removed.connect (header_bar.remove_camera_option);
-        camera_view.camera_present.connect (header_bar.enable_all_controls);
-        header_bar.request_camera_change.connect (camera_view.change_camera);
 
-        timer_running = false;
+        header_bar.request_camera_change.connect (camera_view.change_camera);
 
         camera_view.start ();
 

--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -33,9 +33,8 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
     private Gst.Video.ColorBalance color_balance;
     private Gst.Video.Direction? hflip;
     private Gst.Bin? record_bin;
-
+    private uint n_cameras = 0;
     private Gst.DeviceMonitor monitor = new Gst.DeviceMonitor ();
-    private Gee.HashMap<string, Gst.Device> cameras = new Gee.HashMap<string, Gst.Device> ();
     public bool recording { get; private set; default = false; }
     public bool horizontal_flip {
         get {
@@ -58,9 +57,8 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
         }
     }
 
-    public signal void camera_added (string name);
-    public signal void camera_removed (string name);
-    public signal void camera_present (bool present);
+    public signal void camera_added (Gst.Device camera);
+    public signal void camera_removed (Gst.Device camera);
 
     construct {
         var spinner = new Gtk.Spinner ();
@@ -90,45 +88,20 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
         monitor.add_filter ("Video/Source", caps);
     }
 
-    private void on_device_added (Gst.Device device) {
-        if (add_camera_to_map (device)) {
-            if (cameras.size == 1) {
-                start_view (cameras.keys.to_array ()[0]);
-            } else {
-                int num_cams = cameras.keys.size;
-                change_camera (cameras.keys.to_array ()[num_cams - 1]);
-            }
-
-            camera_present (true);
-        } else {
-            warning ("CameraView: Attempt to add camera that is already in list");
-        }
+    private void on_camera_added (Gst.Device device) {
+        n_cameras++;
+        camera_added (device);
+        change_camera (device);
     }
-
-    private bool add_camera_to_map (Gst.Device device) {
-        var name = device.get_display_name ().strip ();
-        if (cameras.has_key (name)) {
-            return false;
+    private void on_camera_removed (Gst.Device device) {
+        n_cameras--;
+        camera_removed (device);
+        if (n_cameras == 0) {
+            no_device_view.show ();
+            visible_child = no_device_view;
         } else {
-            cameras.set (name, device);
-            camera_added (name);
-            return true;
+            change_camera (monitor.get_devices ().nth_data (0));
         }
-    }
-
-    private bool remove_camera_from_map (Gst.Device device) {
-        var name = device.get_display_name ().strip ();
-        if (cameras.has_key (name)) {
-            cameras.unset (name);
-            camera_removed (name);
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    private Gst.Device? find_camera_from_name (string name) {
-        return cameras.get (name.strip ());
     }
 
     private bool on_bus_message (Gst.Bus bus, Gst.Message message) {
@@ -136,29 +109,20 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
             case DEVICE_ADDED:
                 Gst.Device device;
                 message.parse_device_added (out device);
-                on_device_added (device);
+                on_camera_added (device);
 
                 break;
             case DEVICE_CHANGED:
                 Gst.Device device, changed_device;
                 message.parse_device_changed (out device, out changed_device);
-                remove_camera_from_map (changed_device);
-                add_camera_to_map (device);
+                on_camera_removed (changed_device);
+                on_camera_added (device);
+
                 break;
             case DEVICE_REMOVED:
                 Gst.Device device;
                 message.parse_device_removed (out device);
-                if (remove_camera_from_map (device)) {
-                    if (cameras.size == 0) {
-                        no_device_view.show ();
-                        camera_present (false);
-                        visible_child = no_device_view;
-                    } else {
-                        change_camera (cameras.keys.to_array ()[0]);
-                    }
-                } else {
-                    warning ("CameraView: Attempt to remove camera that is not in list");
-                }
+                on_camera_removed (device);
 
                 break;
             default:
@@ -170,20 +134,15 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
 
     public void start () {
         monitor.get_devices ().foreach ((dev) => {
-            on_device_added (dev);
+            on_camera_added (dev);
         });
         monitor.start ();
-
-        if (cameras.size == 0) {
-            no_device_view.show ();
-            camera_present (false);
-            visible_child = no_device_view;
-        } else {
-            camera_present (true);
-        }
     }
 
-    public void change_camera (string display_name) {
+    public void change_camera (Gst.Device camera) {
+        visible_child = status_grid;
+        status_label.label = _("Connecting to \"%s\"…").printf (camera.display_name);
+
         if (recording) {
             stop_recording ();
         }
@@ -193,22 +152,21 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
             record_bin.sync_state_with_parent ();
             record_bin.sync_children_states ();
         }
-        pipeline.set_state (Gst.State.NULL);
-        pipeline.sync_children_states ();
 
-        Gst.Debug.BIN_TO_DOT_FILE (pipeline, Gst.DebugGraphDetails.VERBOSE, "changing");
+        if (pipeline != null) {
+            pipeline.set_state (Gst.State.NULL);
+            pipeline.sync_children_states ();
 
-        create_pipeline (display_name);
+            Gst.Debug.BIN_TO_DOT_FILE (pipeline, Gst.DebugGraphDetails.VERBOSE, "changing");
+        }
+
+        create_pipeline (camera);
     }
 
-    private void create_pipeline (string display_name) {
-        var camera = find_camera_from_name (display_name);
+    private void create_pipeline (Gst.Device camera) {
         try {
-            if (camera == null) {
-                throw new IOError.NOT_FOUND (_("Could not find “%s”"), display_name);
-            }
             pipeline = (Gst.Pipeline) Gst.parse_launch (
-                "v4l2src device=%s name=v4l2src !".printf (camera.get_properties ().get_string ("device.path")) +
+                "v4l2src device=%s name=%s ! ".printf (camera.get_properties ().get_string ("device.path"), camera.name) +
                 "video/x-raw, width=640, height=480, framerate=30/1 ! " +
                 "videoflip method=horizontal-flip name=hflip ! " +
                 "videobalance name=balance ! " +
@@ -223,22 +181,21 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
             hflip = (pipeline.get_by_name ("hflip") as Gst.Video.Direction);
             color_balance = (pipeline.get_by_name ("balance") as Gst.Video.ColorBalance);
 
-            var gtksink = pipeline.get_by_name ("gtksink");
-            gtksink.get ("widget", out gst_video_widget);
-
             if (gst_video_widget != null) {
                 remove (gst_video_widget);
             }
+
+            var gtksink = pipeline.get_by_name ("gtksink");
+            gtksink.get ("widget", out gst_video_widget);
+
             add (gst_video_widget);
             gst_video_widget.show ();
 
             visible_child = gst_video_widget;
             pipeline.set_state (Gst.State.PLAYING);
         } catch (Error e) {
-            no_device_view.show ();
-            camera_present (false);
-            visible_child = no_device_view;
-
+            // It is possible that there is another camera present that could selected so do not show
+            // no_device_view
             var dialog = new Granite.MessageDialog.with_image_from_icon_name (_("Unable To View Camera"), e.message, "dialog-error");
             dialog.run ();
             dialog.destroy ();
@@ -250,12 +207,10 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
         color_balance.set_property ("contrast", contrast);
     }
 
-    public void start_view (string display_name) {
+    private void start_view (Gst.Device camera) {
         visible_child = status_grid;
-
-        status_label.label = _("Connecting to \"%s\"…").printf (display_name);
-
-        create_pipeline (display_name);
+        status_label.label = _("Connecting to \"%s\"…").printf (camera.display_name);
+        create_pipeline (camera);
     }
 
     public void take_photo () {

--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -234,12 +234,6 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
         color_balance.set_property ("contrast", contrast);
     }
 
-    private void start_view (Gst.Device camera) {
-        visible_child = status_grid;
-        status_label.label = _("Connecting to \"%s\"…").printf (camera.display_name);
-        create_pipeline (camera);
-    }
-
     public void take_photo () {
         if (recording || pipeline == null) {
             return;

--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -33,7 +33,11 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
     private Gst.Video.ColorBalance color_balance;
     private Gst.Video.Direction? hflip;
     private Gst.Bin? record_bin;
-    private uint n_cameras = 0;
+    public uint n_cameras {
+        get {
+            return monitor.get_devices ().length ();
+        }
+    }
     private Gst.DeviceMonitor monitor = new Gst.DeviceMonitor ();
     public bool recording { get; private set; default = false; }
     public bool horizontal_flip {
@@ -89,12 +93,10 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
     }
 
     private void on_camera_added (Gst.Device device) {
-        n_cameras++;
         camera_added (device);
         change_camera (device);
     }
     private void on_camera_removed (Gst.Device device) {
-        n_cameras--;
         camera_removed (device);
         if (n_cameras == 0) {
             no_device_view.show ();


### PR DESCRIPTION
Fixes #182 
Fixes #186 

This PR is intended to fix some problems related to having two cameras installed (see https://github.com/elementary/camera/issues/182#issuecomment-953182535 for something this might fix).  If the cameras have the same name or if `start_view` is re-entered before the pipeline is setup then no picture is shown.  Some code clean up and simplification was also done, saving some code and reducing the number of entities.

* Pass Device objects between functions and in signals
* Lose unneeded list of devices - store in menuitems
* Lose unneeded camera_present signal
* Headerbar takes care of enabling controls
* Simplify