### PR TITLE
Select camera if multiple available

### DIFF
--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -259,10 +259,10 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
             var el = camera_options.get_children ().nth_data (0) as Gtk.RadioMenuItem;
             menuitem.join_group (el);
         }
+        menuitem.active = true;
         menuitem.activate.connect (() => {
             request_camera_change (menuitem.label);
         });
-        menuitem.active = true;
         menuitem.show ();
 
         update_take_button ();

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -259,10 +259,10 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
             var el = camera_options.get_children ().nth_data (0) as Gtk.RadioMenuItem;
             menuitem.join_group (el);
         }
-        menuitem.active = true;
         menuitem.activate.connect (() => {
             request_camera_change (menuitem.label);
         });
+        menuitem.active = true;
         menuitem.show ();
 
         update_take_button ();


### PR DESCRIPTION
Closes #186 

Because `Gee.HashMap` does not preserve insertion order access to the cameras was always alpahabetically sorted. Therefore the selected item in the dropdown in the headerbar was not the camera actually selected.