### PR TITLE
Fix Duplicated MenuButton declaration

### DIFF
--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -178,7 +178,6 @@ public class Camera.Widgets.HeaderBar : Gtk.HeaderBar {
             tooltip_text = _("Settings")
         };
 
-        camera_menu_button = new Gtk.MenuButton ();
         camera_options = new Gtk.Menu ();
 
         camera_menu_button = new Gtk.MenuButton () {


### PR DESCRIPTION
The camera_menu_button is duplicated in HeaderBar.vala so it must be removed.