### PR TITLE
CameraView: limit the max rate to 30fps in the preview

### DIFF
--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -197,6 +197,7 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
                 "videoflip method=horizontal-flip name=hflip ! " +
                 "videobalance name=balance ! " +
                 "tee name=tee ! " +
+                "videorate name=videorate ! " +
                 "queue leaky=downstream max-size-buffers=10 ! " +
                 "videoconvert ! " +
                 "videoscale name=videoscale"
@@ -211,6 +212,10 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
             if (gst_video_widget != null) {
                 remove (gst_video_widget);
             }
+
+            dynamic Gst.Element videorate = pipeline.get_by_name ("videorate");
+            videorate.max_rate = 30;
+            videorate.drop_only = true;
 
             dynamic Gst.Element gtksink = Gst.ElementFactory.make ("gtkglsink", null);
             if (gtksink != null) {


### PR DESCRIPTION
This ensures that we don't use all the resources just to show a preview.