### PR TITLE
Ensure pipeline restarts and controls function after taking photo

### DIFF
--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -34,6 +34,7 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
     private Gst.Video.ColorBalance color_balance;
     private Gst.Video.Direction? hflip;
     private Gst.Bin? record_bin;
+    private Gst.Device? current_device = null;
 
     public uint n_cameras {
         get {
@@ -168,6 +169,7 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
         }
 
         create_pipeline (camera);
+        current_device = camera;
     }
 
     private void create_pipeline (Gst.Device camera) {
@@ -285,16 +287,16 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
         filesink.get_static_pad ("sink").add_probe (Gst.PadProbeType.EVENT_DOWNSTREAM, (pad, info) => {
             if (info.get_event ().type == Gst.EventType.EOS) {
                 Idle.add (() => {
-                    picture_pipeline.set_state (Gst.State.PAUSED);
                     picture_pipeline.set_state (Gst.State.NULL);
-
-                    pipeline.set_state (Gst.State.PLAYING);
+                    create_pipeline (current_device);
+                    play_shutter_sound ();
                     recording = false;
                     return Source.REMOVE;
                 });
 
                 return Gst.PadProbeReturn.REMOVE;
             }
+
             return Gst.PadProbeReturn.PASS;
         });
 
@@ -302,7 +304,6 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
         picture_pipeline.sync_children_states ();
 
         Gst.Debug.BIN_TO_DOT_FILE (pipeline, Gst.DebugGraphDetails.VERBOSE, "snapshot");
-        play_shutter_sound ();
     }
 
     public void start_recording () {

--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -288,8 +288,9 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
             if (info.get_event ().type == Gst.EventType.EOS) {
                 Idle.add (() => {
                     picture_pipeline.set_state (Gst.State.NULL);
-                    create_pipeline (current_device);
                     play_shutter_sound ();
+                    create_pipeline (current_device);
+
                     recording = false;
                     return Source.REMOVE;
                 });


### PR DESCRIPTION
Fixes #221
Incidentally fixes #7 (?)

This recreates the current pipeline after take photo instead of setting the state to PLAYING (which does not seem to work after setting the state to NULL).

This incidentally provides a possible fix for #7 since the preview goes black while the pipeline is recreated.  The sound effect is played just before recreating the pipeline so the sound and visual effects are more closely synchronized.

I suspect more elegant solutions are possible but I am not sufficiently knowledgeable of GStreamer atm.