### PR TITLE
Prepare CameraView for GTK4

### DIFF
--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -20,7 +20,7 @@
  *              Corentin Noël <corentin@elementary.io>
  */
 
-public class Camera.Widgets.CameraView : Gtk.Container {
+public class Camera.Widgets.CameraView : Gtk.Box {
     private const string VIDEO_SRC_NAME = "v4l2src";
     public signal void recording_finished (string file_path);
 

--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -20,10 +20,11 @@
  *              Corentin Noël <corentin@elementary.io>
  */
 
-public class Camera.Widgets.CameraView : Gtk.Stack {
+public class Camera.Widgets.CameraView : Gtk.Container {
     private const string VIDEO_SRC_NAME = "v4l2src";
     public signal void recording_finished (string file_path);
 
+    private Gtk.Stack main_widget;
     private Gtk.Box status_box;
     private Granite.Widgets.AlertView no_device_view;
     private Gtk.Label status_label;
@@ -72,6 +73,9 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
     public signal void camera_removed (Gst.Device camera);
 
     construct {
+        main_widget = new Gtk.Stack ();
+        add (main_widget); // can be changed to child = main_widget in GTK4;
+
         var spinner = new Gtk.Spinner ();
         spinner.active = true;
 
@@ -90,8 +94,8 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
             ""
         );
 
-        add (status_box);
-        add (no_device_view);
+        main_widget.add (status_box); // must be add_child for GTK4
+        main_widget.add (no_device_view); // must be add_child for GTK4
         monitor.get_bus ().add_watch (GLib.Priority.DEFAULT, on_bus_message);
 
         var caps = new Gst.Caps.empty_simple ("video/x-raw");
@@ -106,7 +110,7 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
         camera_removed (device);
         if (n_cameras == 0) {
             no_device_view.show ();
-            visible_child = no_device_view;
+            main_widget.visible_child = no_device_view;
         } else {
             change_camera (monitor.get_devices ().nth_data (0));
         }
@@ -148,7 +152,7 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
     }
 
     public void change_camera (Gst.Device camera) {
-        visible_child = status_box;
+        main_widget.visible_child = status_box;
         status_label.label = _("Connecting to \"%s\"…").printf (camera.display_name);
 
         if (recording) {
@@ -212,7 +216,7 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
             color_balance = (pipeline.get_by_name ("balance") as Gst.Video.ColorBalance);
 
             if (gst_video_widget != null) {
-                remove (gst_video_widget);
+                main_widget.remove (gst_video_widget);
             }
 
             dynamic Gst.Element videorate = pipeline.get_by_name ("videorate");
@@ -233,10 +237,10 @@ public class Camera.Widgets.CameraView : Gtk.Stack {
 
             gst_video_widget = gtksink.widget;
 
-            add (gst_video_widget);
+            main_widget.add (gst_video_widget); // must be add_child for GTK4
             gst_video_widget.show ();
 
-            visible_child = gst_video_widget;
+            main_widget.visible_child = gst_video_widget;
             pipeline.set_state (Gst.State.PLAYING);
         } catch (Error e) {
             // It is possible that there is another camera present that could selected so do not show


### PR DESCRIPTION
This aims to prepare `CameraView.vala` for `GTK4` since we can't subclass `Gtk.Stack` in `GTK4` anymore. I tried using `Gtk.Widget` (Gtk3 version), but it seems that it cannot have children on its own without using `Gtk.Container` unlike the `Gtk.Widget` in GTK4. However, using `Gtk.Container` for now will not cause significant regressions when we use `Gtk.Widget` for GTK4.

@jeremypw @danrabbit this is the new pr because I might had accidentally deleted my fork. 