### PR TITLE
Show error in case no camera device is available

### DIFF
--- a/data/io.elementary.camera.appdata.xml.in
+++ b/data/io.elementary.camera.appdata.xml.in
@@ -12,6 +12,14 @@
     <p>Camera is a simple app to take photos with a webcam.</p>
   </description>
   <releases>
+    <release version="6.1.1" date="2022-06-04" urgency="medium">
+      <description>
+        <p>Fixes:</p>
+        <ul>
+          <li>Show error in case no camera device is available</li>
+        </ul>
+      </description>
+    </release>
     <release version="6.1.0" date="2022-06-03" urgency="medium">
       <description>
         <p>New features:</p>

--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -36,6 +36,7 @@ public class Camera.Widgets.CameraView : Gtk.Box {
     private Gst.Video.Direction? hflip;
     private Gst.Bin? record_bin;
     private Gst.Device? current_device = null;
+    private uint init_device_timeout_id = 0;
 
     public uint n_cameras {
         get {
@@ -100,9 +101,21 @@ public class Camera.Widgets.CameraView : Gtk.Box {
 
         var caps = new Gst.Caps.empty_simple ("video/x-raw");
         monitor.add_filter ("Video/Source", caps);
+
+        init_device_timeout_id = Timeout.add_seconds (2, () => {
+            if (n_cameras == 0) {
+                no_device_view.show ();
+                main_widget.visible_child = no_device_view;
+            }
+            return Source.REMOVE;
+        });
     }
 
     private void on_camera_added (Gst.Device device) {
+        if (init_device_timeout_id > 0) {
+            Source.remove (init_device_timeout_id);
+            init_device_timeout_id = 0;
+        }
         camera_added (device);
         change_camera (device);
     }
@@ -138,6 +151,7 @@ public class Camera.Widgets.CameraView : Gtk.Box {
 
                 break;
             default:
+                debug ("on_bus_message of type '%s' received and ignored.", message.type.get_name ());
                 break;
         }
 

--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -151,7 +151,6 @@ public class Camera.Widgets.CameraView : Gtk.Box {
 
                 break;
             default:
-                debug ("on_bus_message of type '%s' received and ignored.", message.type.get_name ());
                 break;
         }
 


### PR DESCRIPTION
Here we are making sure to display an error message to the user in case there is no camera device available at all. Before this change the Camera app does start showing an endlessly spinning spinner which leaves the user under the impression of the app not working correctly.

Tested this in a VM, which shows the error message after 2s - and on bare metal where the camera is still initialized correctly.