### PR TITLE
Add image/jpeg caps to device filter to support MJPEG webcams

### DIFF
--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -100,6 +100,7 @@ public class Camera.Widgets.CameraView : Gtk.Box {
         monitor.get_bus ().add_watch (GLib.Priority.DEFAULT, on_bus_message);
 
         var caps = new Gst.Caps.empty_simple ("video/x-raw");
+        caps.append (new Gst.Caps.empty_simple ("image/jpeg"));
         monitor.add_filter ("Video/Source", caps);
 
         init_device_timeout_id = Timeout.add_seconds (2, () => {


### PR DESCRIPTION
Turned out there is another capability needed to support some webcams which produce MJPEG streams. They don't advertise the `video/x-raw` capability but support `image/jpeg` instead: https://oz9aec.net/software/gstreamer/webcam-pixel-formats-and-gstreamer-caps-filters

This PR makes sure we are filtering for any one of those two capabilities when looking for a supported device. This fixes #236 (see screenshot below) and _might_ fix as well (needs testing from the corresponding users): https://github.com/elementary/camera/issues/175, https://github.com/elementary/camera/issues/151, https://github.com/elementary/camera/issues/149, https://github.com/elementary/camera/issues/121, https://github.com/elementary/camera/issues/115

![Screenshot from 2022-06-04 21 12 20@2x](https://user-images.githubusercontent.com/392542/172022564-22b184a8-f510-4834-9f8d-4d685b7424db.png)
