### PR TITLE
Use portal to request access to camera

### DIFF
--- a/io.elementary.camera.yml
+++ b/io.elementary.camera.yml
@@ -11,7 +11,6 @@ finish-args:
   - '--socket=fallback-x11'
   - '--socket=wayland'
   - '--socket=pulseaudio'
-  - '--device=all'
 
   - '--metadata=X-DConf=migrate-path=/io/elementary/camera/'
 cleanup:
@@ -29,6 +28,17 @@ modules:
       - type: git
         url: http://git.0pointer.net/clone/libcanberra.git
         disable-shallow-clone: true
+
+  - name: portal
+    buildsystem: meson
+    config-opts:
+      - '-Ddocs=false'
+      - '-Dtests=false'
+      - '-Dbackends=gtk3'
+    sources:
+      - type: git
+        url: https://github.com/flatpak/libportal.git
+        tag: 0.6
 
   - name: camera
     buildsystem: meson

--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,7 @@ executable(
         dependency('gtk+-3.0'),
         dependency('libcanberra'),
         dependency('libhandy-1', version: '>=0.90.0'),
+        dependency('libportal'),
         meson.get_compiler('vala').find_library('posix')
     ],
     install : true


### PR DESCRIPTION
... instead of the `--device=all` flag. Eventually fixes https://github.com/elementary/camera/issues/234 - however, I don't know how to effectively use the camera after the access was granted.

After access was granted, we should somehow provide the device to gstreamer so we are able to use it around here: https://github.com/elementary/camera/blob/portal/access_camera/src/Widgets/CameraView.vala#L121-L123

Anyone an idea? 