### PR TITLE
meson: Fix deprecated source_root

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -23,14 +23,14 @@ i18n.merge_file(
     output : meson.project_name() + '.desktop',
     install : true,
     install_dir : join_paths(get_option('datadir'), 'applications'),
-    po_dir : join_paths(meson.source_root(), 'po', 'extra'),
+    po_dir : join_paths(meson.project_source_root(), 'po', 'extra'),
     type : 'desktop'
 )
 
 i18n.merge_file(
     input: 'camera.metainfo.xml.in',
     output: meson.project_name() + '.metainfo.xml',
-    po_dir: meson.source_root() / 'po' / 'extra',
+    po_dir: meson.project_source_root() / 'po' / 'extra',
     type: 'xml',
     install: true,
     install_dir: get_option('datadir') / 'metainfo',

--- a/po/extra/meson.build
+++ b/po/extra/meson.build
@@ -1,6 +1,6 @@
 i18n.gettext(
     'extra',
-    args : '--directory=' + meson.source_root(),
+    args : '--directory=' + meson.project_source_root(),
     install : false,
     preset: 'glib'
 )

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,5 +1,5 @@
 i18n.gettext(meson.project_name(),
-    args: ['--directory=' + meson.source_root()],
+    args: ['--directory=' + meson.project_source_root()],
     preset: 'glib'
 )
 subdir('extra')


### PR DESCRIPTION
Fixes the following warning on build:

```
WARNING: Deprecated features used:
 * 0.56.0: {'meson.source_root'}
```