### PR TITLE
MainWindow: Make headerbar buttons insensitive by default

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -272,7 +272,7 @@ public class Camera.MainWindow : Gtk.ApplicationWindow {
             }
         });
 
-        enable_header (true);
+        enable_header (false);
         return header_widget;
     }
 


### PR DESCRIPTION
Fixes #275

Testes on a PC with no cameras and on a MacBook Air with an iSight camera.