### PR TITLE
Flatpak: Fix warning about redirect

### DIFF
--- a/io.elementary.camera.yml
+++ b/io.elementary.camera.yml
@@ -41,7 +41,7 @@ modules:
     buildsystem: simple
     sources:
     - type: git
-      url: https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs
+      url: https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git
       branch: '0.12'
     build-options:
       build-args:


### PR DESCRIPTION
Fixes the following warning when building with flatpak-builder:

```
warning: redirecting to https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git/
Fetching git repo https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs, ref refs/heads/0.12
warning: redirecting to https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git/
```
