### PR TITLE
Flatpak: Use tarball instead of git for libcamberra

### DIFF
--- a/io.elementary.camera.yml
+++ b/io.elementary.camera.yml
@@ -57,9 +57,9 @@ modules:
       - '--disable-static'
       - '--with-builtin=dso'
     sources:
-      - type: git
-        url: http://git.0pointer.net/clone/libcanberra.git
-        disable-shallow-clone: true
+      - type: archive
+        url: http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz
+        sha256: c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72
 
   - name: camera
     buildsystem: meson


### PR DESCRIPTION
The git repository had existed until Dec 23, 2025 at least but seems to be gone now, resulting build error.
So, replace with tarball which is still available.

The sha256 is taken from the OE recipe:

https://git.openembedded.org/meta-openembedded/tree/meta-oe/recipes-support/libcanberra/libcanberra_0.30.bb?h=scarthgap#n18