### PR TITLE
Fix photo resolution, recording quality, and blank preview for raw-only cameras

### DIFF
--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -350,6 +350,14 @@ public class Camera.Widgets.CameraView : Gtk.Box {
         var encoder = Gst.ElementFactory.make ("vp8enc", null);
         if (encoder == null) {
             missing_messages += Gst.PbUtils.missing_element_installer_detail_new ("vp8enc");
+        } else {
+            // vp8enc defaults (256 kbps target, exhaustive-quality deadline)
+            // cannot encode HD in real time: frames drop and quality collapses
+            encoder["deadline"] = (int64) 1;
+            encoder["cpu-used"] = 4;
+            encoder["threads"] = (int) GLib.get_num_processors ();
+            encoder["keyframe-max-dist"] = 60;
+            encoder["target-bitrate"] = picture_width * picture_height * 4;
         }
 
         var muxer = Gst.ElementFactory.make ("webmmux", null);

--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -249,6 +249,14 @@ public class Camera.Widgets.CameraView : Gtk.Box {
             videorate.drop_only = true;
 
             dynamic Gst.Element gtksink = Gst.ElementFactory.make ("gtk4paintablesink", "sink");
+            if (gtksink == null) {
+                // Without this check the preview silently stays black while
+                // capture keeps working, since the preview branch dead-ends
+                // behind the leaky queue
+                string[] messages = { Gst.PbUtils.missing_element_installer_detail_new ("gtk4paintablesink") };
+                Gst.PbUtils.install_plugins_async (messages, null, (result) => {});
+                throw new IOError.NOT_FOUND ("Missing GStreamer element \"gtk4paintablesink\"");
+            }
 
             pipeline.add (gtksink);
             pipeline.get_by_name ("videoscale").link (gtksink);

--- a/src/Widgets/CameraView.vala
+++ b/src/Widgets/CameraView.vala
@@ -211,7 +211,10 @@ public class Camera.Widgets.CameraView : Gtk.Box {
 
             for (uint i = 0; i < caps.get_size (); i++) {
                 unowned var s = caps.get_structure (i);
-                if (s.get_name () == "image/jpeg") {
+                // Consider raw modes too: some cameras (e.g. the PCIe FaceTime
+                // HD on 2015 MacBook Pros) offer no JPEG caps at all, and the
+                // 640×480 fallback distorts photos from 16:9-only sensors
+                if (s.get_name () == "image/jpeg" || s.get_name () == "video/x-raw") {
                     int w, h;
                     s.get_int ("width", out w);
                     s.get_int ("height", out h);


### PR DESCRIPTION
## What this does

Three small fixes to `CameraView.vala` (20 lines total), each independent:

1. **Consider raw caps when picking photo resolution.** Photo sizing only
   inspected `image/jpeg` capabilities. A camera that exposes only raw
   formats always fell through to the 640×480 default, and photos from a
   16:9-only sensor were stretched to 4:3. Now `video/x-raw` structures
   are scanned too, so photos use the sensor's native resolution.

2. **Configure `vp8enc` for realtime capture.** The encoder was created
   with its defaults (256 kbps target, best-quality/slowest deadline),
   which can't encode an HD stream in real time — the encoder falls
   behind, the leaky preview queue drops frames, and recordings come out
   choppy at ~80 kbps for 720p30. This sets the realtime deadline,
   spreads work across the available CPU cores, and scales the target
   bitrate with frame size (~3.7 Mbps at 720p).

3. **Handle a missing `gtk4paintablesink`.** Every element in the
   recording path reports a missing-plugin message, but the preview sink
   was used unchecked. Without the GTK4 GStreamer plugin the preview
   silently stayed black while photos and recording kept working. This
   adds the same missing-plugin handling and surfaces the existing
   "Unable To View Camera" dialog.

## Why

I hit all three on a 2015 MacBook Pro (MacBookPro11,4), whose FaceTime HD
webcam is a PCIe device driven by the out-of-tree
[facetimehd](https://github.com/patjak/facetimehd) driver and exposes
only raw (non-JPEG) formats. The bugs are general, though — any raw-only
camera hits #1 and #2, and #3 affects any host missing the GTK4 sink.

## Before / after (measured on that machine)

| | before | after |
|---|---|---|
| photo resolution | 640×480, wrong aspect | 1280×720, correct |
| recording bitrate (720p30) | ~80 kbps | ~2 Mbps |
| recording smoothness | drops frames | smooth |
| preview, GTK4 sink missing | silent black screen | clear error dialog |

## Testing

Built against current `main` (`meson` + `ninja`, compiles clean) and run
on the hardware above: photos now save at native resolution, recordings
are smooth, and removing the GTK4 sink produces the error dialog instead
of a black screen.
